### PR TITLE
[Issue #17] Disallow bots from viewing messages

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,5 @@
 class MessagesController < ApplicationController
+  before_action :handle_bot_requests, except: :new
   before_action :set_message, only: [:show, :destroy]
 
   # GET /messages/1
@@ -7,7 +8,7 @@ class MessagesController < ApplicationController
     if @message
       @message.add_view
       notice
-      flash[:notice] = "This message has beed deleted from our records.  You must copy the message elsewhere if you wish to keep it any longer." if @message.remaining_views == 0
+      flash[:notice] = 'This message has beed deleted from our records.  You must copy the message elsewhere if you wish to keep it any longer.' if @message.remaining_views == 0
       redirect_to @message, notice: 'Sorry, that message has expired. Care to create a new one?' if @message.time_left < 0
     else
       redirect_to root_url, notice: 'Sorry, that message has expired or never existed at all. Care to create a new one?'
@@ -23,10 +24,9 @@ class MessagesController < ApplicationController
   # POST /messages.json
   def create
     @message = Message.new(message_params)
-
     respond_to do |format|
       if @message.save
-        format.html { redirect_to message_url(@message.token) }
+        format.html { redirect_to message_url(@message) }
         format.json { render :show, status: :created, location: @message }
       else
         format.html { render :new }
@@ -34,7 +34,6 @@ class MessagesController < ApplicationController
       end
     end
   end
-
 
   # DELETE /messages/1
   # DELETE /messages/1.json
@@ -47,14 +46,22 @@ class MessagesController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_message
-      @message = Message.find_by_token(params[:token])
-    end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def message_params
-      params.require(:message).permit(:body, :max_views, :hours)
-    end
-    
+  # Use callbacks to share common setup or constraints between actions.
+  def set_message
+    @message = Message.find_by_token(params[:token])
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def message_params
+    params.require(:message).permit(:body, :max_views, :hours)
+  end
+
+  def handle_bot_requests
+    disallowed_bots = ['Googlebot', 'Yahoo!', 'bingbot', 'AhrefsBot', 'Baiduspider', 'Ezooms',
+                       'MJ12bot', 'YandexBot', 'Slackbot']
+    bot_regexp = /#{disallowed_bots.join('|')}/
+    render template: 'messages/gone', status: 404, layout: nil if
+      bot_regexp === request.user_agent
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -25,6 +25,10 @@ class Message < ActiveRecord::Base
     self.hours - time_elapsed
   end
 
+  def to_param
+    token
+  end
+
   private
 
   def expired_by_time?

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,4 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+
+User-agent: *
+Disallow: /m/

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -24,11 +24,12 @@ RSpec.describe MessagesController, :type => :controller do
   # Message. As you add validations to Message, be sure to
   # adjust the attributes here as well.
   let(:valid_attributes) {
-    skip("Add a hash of attributes valid for your model")
+    # skip("Add a hash of attributes valid for your model")
+    { "body"=>"message body", "max_views"=>(1..10).to_a.sample.to_s, "hours"=>(1..100).to_a.sample.to_s}
   }
 
   let(:invalid_attributes) {
-    skip("Add a hash of attributes invalid for your model")
+    { "message"=> { "body"=>"message body", "max_views"=>"", "hours"=>(1..100).to_a.sample.to_s}}
   }
 
   # This should return the minimal set of values that should be in the session
@@ -36,19 +37,23 @@ RSpec.describe MessagesController, :type => :controller do
   # MessagesController. Be sure to keep this updated too.
   let(:valid_session) { {} }
 
-  describe "GET index" do
-    it "assigns all messages as @messages" do
-      message = Message.create! valid_attributes
-      get :index, {}, valid_session
-      expect(assigns(:messages)).to eq([message])
-    end
-  end
-
   describe "GET show" do
     it "assigns the requested message as @message" do
       message = Message.create! valid_attributes
-      get :show, {:id => message.to_param}, valid_session
+      get :show, {:token => message.to_param}, valid_session
       expect(assigns(:message)).to eq(message)
+    end
+
+    it "does not permit bots" do
+      bots = ['Googlebot', 'Yahoo!', 'bingbot', 'AhrefsBot', 'Baiduspider', 'Ezooms',
+        'MJ12bot', 'YandexBot', 'Slackbot']
+      # request.env['HTTP_USER_AGENT'] = 'Slackbot-LinkExpanding 1.0 ' \
+      #                                  '(+https://api.slack.com/robots)'
+      request.env['HTTP_USER_AGENT'] = bots.sample
+      message = Message.create! valid_attributes
+      get :show, {:token => message.to_param}, valid_session
+      expect(message.views).to eq(-1)
+      expect(response.code.to_i).to eq(404)
     end
   end
 
@@ -56,14 +61,6 @@ RSpec.describe MessagesController, :type => :controller do
     it "assigns a new message as @message" do
       get :new, {}, valid_session
       expect(assigns(:message)).to be_a_new(Message)
-    end
-  end
-
-  describe "GET edit" do
-    it "assigns the requested message as @message" do
-      message = Message.create! valid_attributes
-      get :edit, {:id => message.to_param}, valid_session
-      expect(assigns(:message)).to eq(message)
     end
   end
 
@@ -100,59 +97,18 @@ RSpec.describe MessagesController, :type => :controller do
     end
   end
 
-  describe "PUT update" do
-    describe "with valid params" do
-      let(:new_attributes) {
-        skip("Add a hash of attributes valid for your model")
-      }
-
-      it "updates the requested message" do
-        message = Message.create! valid_attributes
-        put :update, {:id => message.to_param, :message => new_attributes}, valid_session
-        message.reload
-        skip("Add assertions for updated state")
-      end
-
-      it "assigns the requested message as @message" do
-        message = Message.create! valid_attributes
-        put :update, {:id => message.to_param, :message => valid_attributes}, valid_session
-        expect(assigns(:message)).to eq(message)
-      end
-
-      it "redirects to the message" do
-        message = Message.create! valid_attributes
-        put :update, {:id => message.to_param, :message => valid_attributes}, valid_session
-        expect(response).to redirect_to(message)
-      end
-    end
-
-    describe "with invalid params" do
-      it "assigns the message as @message" do
-        message = Message.create! valid_attributes
-        put :update, {:id => message.to_param, :message => invalid_attributes}, valid_session
-        expect(assigns(:message)).to eq(message)
-      end
-
-      it "re-renders the 'edit' template" do
-        message = Message.create! valid_attributes
-        put :update, {:id => message.to_param, :message => invalid_attributes}, valid_session
-        expect(response).to render_template("edit")
-      end
-    end
-  end
-
   describe "DELETE destroy" do
     it "destroys the requested message" do
       message = Message.create! valid_attributes
       expect {
-        delete :destroy, {:id => message.to_param}, valid_session
+        delete :destroy, {:token => message.to_param}, valid_session
       }.to change(Message, :count).by(-1)
     end
 
     it "redirects to the messages list" do
       message = Message.create! valid_attributes
-      delete :destroy, {:id => message.to_param}, valid_session
-      expect(response).to redirect_to(messages_url)
+      delete :destroy, {:token => message.to_param}, valid_session
+      expect(response).to redirect_to(root_url)
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,7 +52,7 @@ RSpec.configure do |config|
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.treat_symbols_as_metadata_keys_with_true_values = true
-  config.order = 'random'
+  config.order = :random
   config.infer_spec_type_from_file_location!
 
   config.include FactoryGirl::Syntax::Methods


### PR DESCRIPTION
### Addresses #17 
Returns 404 status code with no layout when bots attempt to interact with messages. 
Adds rule in robots.txt to disallow bots
Enables messages controller spec

Now, when you share a fugacious link in Slack, there will be no metadata returned and the server will receive 404. 