### PR TITLE
[Issue #66] Adds global retention limit

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,7 +2,10 @@ class Message < ActiveRecord::Base
   before_create :make_token
   validates_presence_of :body, message: "can't be blank"
   validates :max_views, numericality: {greater_than: 0, message: "Views must be greater than 0"} 
-  
+  validates :hours, numericality: {
+    greater_than_or_equal_to: 1,
+    less_than_or_equal_to: Rails.application.secrets.max_retention_hours }
+
   HUMANIZED_ATTRIBUTES = {body: 'Message'}
 
   def self.human_attribute_name(attr, options = {})

--- a/config/initializers/max_retention_hours.rb
+++ b/config/initializers/max_retention_hours.rb
@@ -1,0 +1,4 @@
+hours = Rails.application.secrets.max_retention_hours.to_i || 720
+
+raise 'Rails.application.secrets.max_retention_hours' \
+' exceeds 720 hours (30 days)' if hours > 720

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,13 +13,16 @@
 development:
   secret_key_base: f96a2462114e5687c02ee262895f4d3c556d9dbacc5aaf54ea33da31a84970eade80ae9ed4becb5305bdffea1524725a3f09269a496bbe4f90698ccc4ae15e92
   db_key_base: 92ffd31f3cb355b7252afc4633d60d10e6e2266a5e0b8e456ddf10d3519e4cda2303dbe136d1ae42c168e4ce17ae327c21b0f473cfed22928e4f46700db4d828
+  max_retention_hours: 720
 
 test:
   secret_key_base: 92ffd31f3cb355b7252afc4633d60d10e6e2266a5e0b8e456ddf10d3519e4cda2303dbe136d1ae42c168e4ce17ae327c21b0f473cfed22928e4f46700db4d828
   db_key_base: 92ffd31f3cb355b7252afc4633d60d10e6e2266a5e0b8e456ddf10d3519e4cda2303dbe136d1ae42c168e4ce17ae327c21b0f473cfed22928e4f46700db4d828
+  max_retention_hours: 720
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
   db_key_base: 92ffd31f3cb355b7252afc4633d60d10e6e2266a5e0b8e456ddf10d3519e4cda2303dbe136d1ae42c168e4ce17ae327c21b0f473cfed22928e4f46700db4d828
+  max_retention_hours: <%= ENV['MAX_RETENTION_HOURS'] %>

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -2,45 +2,80 @@ require 'rails_helper'
 
 RSpec.describe Message, type: 'model' do
 
-	it 'is valid with a message body' do
-		expect(Message.new(body: 'may the force be with you')).to be_valid
-	end
+  it 'is valid with a message body' do
+    expect(Message.new(body: 'may the force be with you')).to be_valid
+  end
 
-	it 'is invalid without a message body' do
-		expect(Message.new).to_not be_valid
-		expect(Message.new).to have(1).errors_on(:body)
-	end
+  it 'is invalid without a message body' do
+    expect(Message.new).to_not be_valid
+    expect(Message.new).to have(1).errors_on(:body)
+  end
 
-	it 'is valid with 1 or more max views' do
-		expect(Message.new(body: 'may the force be with you', max_views: 1)).to be_valid
-	end
+  it 'is valid with 1 or more max views' do
+    expect(Message.new(body: 'may the force be with you', max_views: 1)).to be_valid
+  end
 
-	it 'is invalid with less than 1 max view' do
-		expect(Message.new(body: 'may the force be with you', max_views: 0)).to_not be_valid
-		expect(Message.new(body: 'may the force be with you', max_views: 0)).to have(1).errors_on(:max_views)
-	end
+  it 'is invalid with less than 1 max view' do
+    expect(Message.new(body: 'may the force be with you', max_views: 0)).to_not be_valid
+    expect(Message.new(body: 'may the force be with you', max_views: 0)).to have(1).errors_on(:max_views)
+  end
 
-	it 'humanizes the body attribute with "Message"' do
-		expect(Message.human_attribute_name(:body)).to eq('Message')
-	end
+  it 'humanizes the body attribute with "Message"' do
+    expect(Message.human_attribute_name(:body)).to eq('Message')
+  end
 
-	describe '@instance_methods' do
-		let(:message) { FactoryGirl.create(:message) }
+  it 'is invalid with less than 1 hour time limit' do
+    expect(Message.new(body: 'merp', max_views: 1, hours: 0)).to_not be_valid
+    expect(Message.new(body: 'merp', max_views: 1, hours: 0)).to have(1).errors_on(:hours)
+  end
 
-		it 'adds to the view count when the #add_view method is called' do
-			views = message.views
-			message.add_view
-			
-			expect(message.views).to eq(views+1)
-		end
+  describe '@instance_methods' do
+    let(:message) { FactoryGirl.create(:message) }
 
-		it 'deletes the message if it has expired from the #add_view method' do
-			message.views = message.max_views-1
-			message.add_view
+    it 'adds to the view count when the #add_view method is called' do
+      views = message.views
+      message.add_view
 
-			expect(Message.exists?(message.id)).to be false
-		end
+      expect(message.views).to eq(views+1)
+    end
 
-		
-	end
+    it 'deletes the message if it has expired from the #add_view method' do
+      message.views = message.max_views-1
+      message.add_view
+
+      expect(Message.exists?(message.id)).to be false
+    end
+  end
+
+  describe 'a global retention limit' do
+    let(:message) { Message.new(body: 'turtles', max_views: 2) }
+
+    context 'with a valid global limit' do
+      it 'can not exceed the specified limit' do
+        message.hours = Rails.application.secrets.max_retention_hours + 1
+
+        expect(message.save).to be_falsey
+        expect(message.errors.include?(:hours)).to be_truthy
+      end
+
+      it 'can be within the limit' do
+        message.hours = Rails.application.secrets.max_retention_hours / 2
+
+        expect { message.save }.to_not raise_error
+      end
+    end
+
+    context 'with a limit exceeding 30 days' do
+      let(:message) { Message.new(body: 'turtles', max_views: 2) }
+
+      it 'raises exception upon initialization' do
+        allow(Rails.application.secrets).to receive(:max_retention_hours).
+          and_return(721)
+
+        expect {
+            load File.join(Rails.root, 'config', 'initializers', 'max_retention_hours.rb')
+          }.to raise_error(RuntimeError, 'Rails.application.secrets.max_retention_hours exceeds 720 hours (30 days)')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds global retention limit of 720 hours
Allows retention limit to be configured per instance <= 720
Adds minimum value validation as well >= 1