### PR TITLE
Adds Ruby 1.9.3 to travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ cache: bundler
 matrix:
   fast_finish: true
   include:
-    - rvm: 2.2.3
-    - rvm: 2.3.0
+    - rvm: 1.9.3
+    - rvm: 2.3.1
 
 notifications:
   email: false


### PR DESCRIPTION
We're no longer Ruby 1.9 compatible. 

> Gem::InstallError: tins requires Ruby version >= 2.0.

@jgrevich I just want to make sure it's OK that we drop 1.9 support. I will update the README if you give the 👌 