### PR TITLE
Use helper library to parse cloud foundry environment.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,4 +74,5 @@ group :production do
   # Use postgresql as the database for Active Record
   gem 'pg'
   gem 'rails_12factor'
+  gem 'cf-app-utils'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,7 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
+    cf-app-utils (0.6)
     chef (12.0.3)
       chef-zero (~> 3.2)
       diff-lcs (~> 1.2, >= 1.2.4)
@@ -649,6 +650,7 @@ DEPENDENCIES
   capybara (~> 2.3.0)
   capybara-screenshot
   capybara-webkit
+  cf-app-utils
   coffee-rails (~> 4.0.0)
   coveralls
   database_cleaner
@@ -695,4 +697,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.13.0
+   1.13.6

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,12 +14,8 @@ test:
   database: db/fugacious_test.sqlite3
 
 <%
-  begin
-    services = JSON.parse(ENV['VCAP_SERVICES'])
-    credentials = services['aws-rds'].first['credentials']
-  rescue
-    credentials = {}
-  end
+  require 'cf-app-utils'
+  credentials = CF::App::Credentials.find_by_service_name('postgres') || {} rescue {}
 %>
 
 <% if !credentials.empty? %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,25 +13,9 @@ test:
   <<: *default
   database: db/fugacious_test.sqlite3
 
-<%
-  require 'cf-app-utils'
-  credentials = CF::App::Credentials.find_by_service_name('postgres') || {} rescue {}
-%>
-
-<% if !credentials.empty? %>
-production:
-  adapter: postgresql
-  encoding: unicode
-  host: <%= credentials['hostname'] || 'localhost' %>
-  port: <%= credentials['port'] || '3306' %>
-  database: <%= credentials['name'] || '' %>
-  username: <%= credentials['username'] || '' %>
-  password: <%= credentials['password'] || '' %>
-<% else %>
 production:
   <<: *default
   adapter: postgresql
   database: fugacious_production
   username: fugacious
   password: <%= ENV['FUGACIOUS_DATABASE_PASSWORD'] %>
-<% end %>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,8 @@
+require 'cf-app-utils'
+
 if ENV['VCAP_SERVICES']
-  services = JSON.parse(ENV['VCAP_SERVICES'])
-  credentials = services['redis28'].first['credentials']
-  redis = "redis://:#{credentials['password']}@#{credentials['host']}:#{credentials['port']}"
+  credentials = CF::App::Credentials.find_by_service_name('redis') || {}
+  redis = "redis://:#{credentials['password']}@#{credentials['hostname']}:#{credentials['port']}"
 
   Sidekiq.configure_server do |config|
     config.redis = {url: redis}
@@ -10,5 +11,4 @@ if ENV['VCAP_SERVICES']
   Sidekiq.configure_client do |config|
     config.redis = {url: redis}
   end
-
 end

--- a/lib/tasks/message_task.rake
+++ b/lib/tasks/message_task.rake
@@ -1,8 +1,7 @@
 require_relative '../../app/models/message.rb'
 require_relative '../../app/workers/message_expiry_worker'
- 
+
 namespace :message_task do
- 
   task :check_expiry => :environment do
     puts "Clearing expired messages..."
     Message.all.each do |message|


### PR DESCRIPTION
Using `cf-app-utils` saves a few lines of boilerplate and provides a more intuitive interface for navigating cloud foundry services.