### PR TITLE
Adds CF app utils gem for configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ end
 gem 'sdoc', '~> 0.4.0',          group: :doc
 
 group :production do
-  # Use postgresql as the database for Active Record
+  gem 'cf-app-utils'
   gem 'pg'
   gem 'puma'
   gem 'rails_12factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,7 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
+    cf-app-utils (0.6)
     chef (12.0.3)
       chef-zero (~> 3.2)
       diff-lcs (~> 1.2, >= 1.2.4)
@@ -654,6 +655,7 @@ DEPENDENCIES
   capybara (~> 2.3.0)
   capybara-screenshot
   capybara-webkit
+  cf-app-utils
   coffee-rails (~> 4.0.0)
   coveralls
   database_cleaner

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,29 +13,9 @@ test:
   <<: *default
   database: db/fugacious_test.sqlite3
 
-<%
-  begin
-    services = JSON.parse(ENV['VCAP_SERVICES'])
-    credentials = services['aws-rds'].first['credentials']
-  rescue
-    credentials = {}
-  end
-%>
-
-<% if !credentials.empty? %>
-production:
-  adapter: postgresql
-  encoding: unicode
-  host: <%= credentials['hostname'] || 'localhost' %>
-  port: <%= credentials['port'] || '3306' %>
-  database: <%= credentials['name'] || '' %>
-  username: <%= credentials['username'] || '' %>
-  password: <%= credentials['password'] || '' %>
-<% else %>
 production:
   <<: *default
   adapter: postgresql
   database: fugacious_production
   username: fugacious
   password: <%= ENV['FUGACIOUS_DATABASE_PASSWORD'] %>
-<% end %>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,8 @@
+require 'cf-app-utils'
+
 if ENV['VCAP_SERVICES']
-  services = JSON.parse(ENV['VCAP_SERVICES'])
-  credentials = services['redis28'].first['credentials']
-  redis = "redis://:#{credentials['password']}@#{credentials['host']}:#{credentials['port']}"
+  credentials = CF::App::Credentials.find_by_service_name('redis') || {}
+  redis = "redis://:#{credentials['password']}@#{credentials['hostname']}:#{credentials['port']}"
 
   Sidekiq.configure_server do |config|
     config.redis = {url: redis}
@@ -9,14 +10,5 @@ if ENV['VCAP_SERVICES']
 
   Sidekiq.configure_client do |config|
     config.redis = {url: redis}
-  end
-
-end
-
-Sidekiq.configure_server do |config|
-  schedule_file = "config/sidekiq_schedule.yml"
-
-  if File.exists?(schedule_file) && Sidekiq.server?
-    Sidekiq::Cron::Job.load_from_hash! YAML.load_file(schedule_file)
   end
 end


### PR DESCRIPTION
Rebased @jmcarp's pull request: https://github.com/fugacious/fugacious/pull/83/

> Using cf-app-utils saves a few lines of boilerplate and provides a more intuitive interface for navigating cloud foundry services.