### PR TITLE
pin to ruby 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '~> 2.3.4'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 4.2.7.1'
 


### PR DESCRIPTION
When attempting to deploy this on Ruby 2.4.1, something in the dependencies is attempting to pull in json 1.8.3 triggering this bug: https://github.com/flori/json/issues/303

I didn't have time to debug this beyond pinning this to Ruby 2.3 which solved the problem.  There maybe a better option to fix this 🤷‍♂️ I



