### PR TITLE
Updates capybara gem and dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 4.2.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,7 +358,7 @@ GEM
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
     mime-types (2.99.3)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minitar (0.5.4)
     minitest (5.10.1)
     mixlib-authentication (1.3.0)
@@ -383,8 +383,8 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     netrc (0.11.0)
     nio4r (1.2.1)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     nori (2.6.0)
     notiffany (0.0.8)
       nenv (~> 0.1)
@@ -418,7 +418,7 @@ GEM
     puma (3.6.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.5)
+    rack (1.6.8)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
@@ -633,7 +633,7 @@ GEM
       nori (~> 2.0)
       rubyntlm (~> 0.6.0)
     wmi-lite (1.0.0)
-    xpath (2.0.0)
+    xpath (2.1.0)
       nokogiri (~> 1.3)
     yard (0.8.7.6)
 
@@ -694,4 +694,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.6
+   1.15.4


### PR DESCRIPTION
Updates nokogiri to 1.8.1 
Fetches github gems over https

Resolves the following warnings/CVEs:
- https://hakiri.io/github/fugacious/fugacious/dev/b006e2f7202cbe37fcc2e7dbe88077b47ebba920/warnings?name=Denial+of+Service
- https://hakiri.io/github/fugacious/fugacious/dev/b006e2f7202cbe37fcc2e7dbe88077b47ebba920/warnings?name=Buffer+Errors