### PR TITLE
Remove devops group from bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,15 +54,6 @@ group :development do
   gem 'unf'
 end
 
-group :devops do
-  gem 'berkshelf'
-  gem 'capistrano-rails'
-  gem 'knife-ec2'
-  gem 'knife-solo', github: 'matschaffer/knife-solo', submodules: true
-  gem 'knife-solo_data_bag'
-  gem 'rvm-capistrano'
-end
-
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0',          group: :doc
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,20 +5,9 @@ GIT
     uswds-rails (1.0.0)
       sass
 
-GIT
-  remote: https://github.com/matschaffer/knife-solo.git
-  revision: 98a4d7f08cbd6b053a6c580faab1babc1c390958
-  submodules: true
-  specs:
-    knife-solo (0.7.0.pre)
-      chef (>= 10.20)
-      erubis (~> 2.7.0)
-      net-ssh (>= 2.7)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.2)
     actionmailer (4.2.10)
       actionpack (= 4.2.10)
       actionview (= 4.2.10)
@@ -58,26 +47,6 @@ GEM
     autoprefixer-rails (6.3.1)
       execjs
       json
-    berkshelf (4.2.1)
-      addressable (~> 2.3.4)
-      berkshelf-api-client (~> 2.0)
-      buff-config (~> 1.0)
-      buff-extensions (~> 1.0)
-      buff-shell_out (~> 0.1)
-      celluloid (= 0.16.0)
-      celluloid-io (~> 0.16.1)
-      cleanroom (~> 1.0)
-      faraday (~> 0.9.0)
-      httpclient (~> 2.7.0)
-      minitar (~> 0.5.4)
-      octokit (~> 4.0)
-      retryable (~> 2.0)
-      ridley (~> 4.4.3)
-      solve (~> 2.0)
-      thor (~> 0.19)
-    berkshelf-api-client (2.0.1)
-      faraday (~> 0.9.1)
-      httpclient (~> 2.7.0)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -96,23 +65,7 @@ GEM
       sass (~> 3.0)
       slim (>= 1.3.6, < 4.0)
       terminal-table (~> 1.4)
-    buff-config (1.0.1)
-      buff-extensions (~> 1.0)
-      varia_model (~> 0.4)
-    buff-extensions (1.0.0)
-    buff-ignore (1.1.1)
-    buff-ruby_engine (0.1.0)
-    buff-shell_out (0.2.0)
-      buff-ruby_engine (~> 0.1.0)
     builder (3.2.3)
-    capistrano (2.15.7)
-      highline
-      net-scp (>= 1.0.0)
-      net-sftp (>= 2.0.0)
-      net-ssh (>= 2.0.14)
-      net-ssh-gateway (>= 1.1.0)
-    capistrano-rails (1.0.0)
-      capistrano
     capybara (2.3.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -122,37 +75,6 @@ GEM
     capybara-screenshot (1.0.11)
       capybara (>= 1.0, < 3)
       launchy
-    celluloid (0.16.0)
-      timers (~> 4.0.0)
-    celluloid-io (0.16.2)
-      celluloid (>= 0.16.0)
-      nio4r (>= 1.1.0)
-    chef (12.0.3)
-      chef-zero (~> 3.2)
-      diff-lcs (~> 1.2, >= 1.2.4)
-      erubis (~> 2.7)
-      ffi-yajl (~> 1.2)
-      highline (~> 1.6, >= 1.6.9)
-      mixlib-authentication (~> 1.3)
-      mixlib-cli (~> 1.4)
-      mixlib-config (~> 2.0)
-      mixlib-log (~> 1.3)
-      mixlib-shellout (>= 2.0.0.rc.0, < 3.0)
-      net-ssh (~> 2.6)
-      net-ssh-multi (~> 1.1)
-      ohai (~> 8.0)
-      plist (~> 3.1.0)
-      pry (~> 0.9)
-    chef-config (12.7.2)
-      mixlib-config (~> 2.0)
-      mixlib-shellout (~> 2.0)
-    chef-zero (3.2.1)
-      ffi-yajl (~> 1.1)
-      hashie (~> 2.0)
-      mixlib-log (~> 1.3)
-      rack
-      uuidtools (~> 2.1)
-    cleanroom (1.0.0)
     cliver (0.3.2)
     coderay (1.1.1)
     coffee-rails (4.0.1)
@@ -186,7 +108,6 @@ GEM
       railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     eventmachine (1.0.9.1)
-    excon (0.45.4)
     execjs (2.6.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -195,106 +116,11 @@ GEM
       railties (>= 3.0.0)
     faker (1.6.1)
       i18n (~> 0.5)
-    faraday (0.9.2)
-      multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
     ffi (1.9.10)
-    ffi-yajl (1.4.0)
-      ffi (~> 1.5)
-      libyajl2 (~> 1.2)
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
-    fog (1.29.0)
-      fog-atmos
-      fog-aws (~> 0.0)
-      fog-brightbox (~> 0.4)
-      fog-core (~> 1.27, >= 1.27.4)
-      fog-ecloud
-      fog-json
-      fog-local
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-      nokogiri (~> 1.5, >= 1.5.11)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
-    fog-aws (0.8.1)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-brightbox (0.10.1)
-      fog-core (~> 1.22)
-      fog-json
-      inflecto (~> 0.0.2)
-    fog-core (1.36.0)
-      builder
-      excon (~> 0.45)
-      formatador (~> 0.2)
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-json (1.0.2)
-      fog-core (~> 1.0)
-      multi_json (~> 1.10)
-    fog-local (0.2.1)
-      fog-core (~> 1.27)
-    fog-powerdns (0.1.1)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-    fog-profitbricks (0.0.5)
-      fog-core
-      fog-xml
-      nokogiri
-    fog-radosgw (0.0.5)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.7.5)
-      fog-core
-      fog-json
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
-    fog-softlayer (1.1.0)
-      fog-core
-      fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-xml (0.1.2)
-      fog-core
-      nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    gssapi (1.2.0)
-      ffi (>= 1.0.1)
     guard (2.13.0)
       formatador (>= 0.2.4)
       listen (>= 2.7, <= 4.0)
@@ -312,17 +138,12 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    gyoku (1.3.1)
-      builder (>= 2.1.2)
     haml (4.0.7)
       tilt
     hashdiff (0.3.7)
-    hashie (2.1.2)
     highline (1.7.8)
-    hitimes (1.2.3)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
-    httpclient (2.7.1)
     i18n (0.9.0)
       concurrent-ruby (~> 1.0)
     inch (0.7.0)
@@ -330,28 +151,15 @@ GEM
       sparkr (>= 0.2.0)
       term-ansicolor
       yard (~> 0.8.7.5)
-    inflecto (0.0.2)
-    ipaddress (0.8.3)
     jbuilder (2.4.0)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
     json (1.8.6)
-    knife-ec2 (0.12.0)
-      fog (~> 1.29.0)
-      knife-windows (~> 1.0)
-    knife-solo_data_bag (1.1.0)
-    knife-windows (1.3.0)
-      winrm (~> 1.7)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libyajl2 (1.2.0)
     listen (3.0.5)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    little-plugger (1.1.4)
-    logging (2.0.0)
-      little-plugger (~> 1.1)
-      multi_json (~> 1.10)
     loofah (2.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -361,52 +169,16 @@ GEM
     method_source (0.8.2)
     mime-types (2.99.3)
     mini_portile2 (2.3.0)
-    minitar (0.5.4)
     minitest (5.10.3)
-    mixlib-authentication (1.3.0)
-      mixlib-log
-    mixlib-cli (1.7.0)
-    mixlib-config (2.2.1)
-    mixlib-log (1.6.0)
-    mixlib-shellout (2.2.6)
-    molinillo (0.2.3)
     multi_json (1.12.1)
-    multipart-post (2.0.0)
     nenv (0.2.0)
-    net-scp (1.2.1)
-      net-ssh (>= 2.6.5)
-    net-sftp (2.1.2)
-      net-ssh (>= 2.6.5)
-    net-ssh (2.9.4)
-    net-ssh-gateway (1.2.0)
-      net-ssh (>= 2.6.5)
-    net-ssh-multi (1.2.1)
-      net-ssh (>= 2.6.5)
-      net-ssh-gateway (>= 1.2.0)
     netrc (0.11.0)
-    nio4r (1.2.1)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
-    nori (2.6.0)
     notiffany (0.0.8)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    octokit (4.2.0)
-      sawyer (~> 0.6.0, >= 0.5.3)
-    ohai (8.4.0)
-      ffi (~> 1.9)
-      ffi-yajl (>= 1.1, < 3.0)
-      ipaddress
-      mime-types (~> 2.0)
-      mixlib-cli
-      mixlib-config (~> 2.0)
-      mixlib-log
-      mixlib-shellout (~> 2.0)
-      rake (~> 10.1)
-      systemu (~> 2.6.4)
-      wmi-lite (~> 1.0)
     pg (0.18.4)
-    plist (3.1.0)
     poltergeist (1.13.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -417,7 +189,7 @@ GEM
       slop (~> 3.4)
     pry-nav (0.2.4)
       pry (>= 0.9.10, < 0.11.0)
-    puma (3.6.0)
+    puma (3.10.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.8)
@@ -467,25 +239,6 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    retryable (2.0.3)
-    ridley (4.4.3)
-      addressable
-      buff-config (~> 1.0)
-      buff-extensions (~> 1.0)
-      buff-ignore (~> 1.1)
-      buff-shell_out (~> 0.1)
-      celluloid (~> 0.16.0)
-      celluloid-io (~> 0.16.1)
-      chef-config (>= 12.5.0)
-      erubis
-      faraday (~> 0.9.0)
-      hashie (>= 2.0.2, < 4.0.0)
-      httpclient (~> 2.7)
-      json (>= 1.7.7)
-      mixlib-authentication (>= 1.3.0)
-      retryable (~> 2.0)
-      semverse (~> 1.1)
-      varia_model (~> 0.4.0)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -516,10 +269,7 @@ GEM
       sexp_processor (~> 4.0)
     ruby_parser (3.7.3)
       sexp_processor (~> 4.1)
-    rubyntlm (0.6.0)
     rufus-scheduler (3.2.2)
-    rvm-capistrano (1.5.6)
-      capistrano (~> 2.15.4)
     safe_yaml (1.0.4)
     sass (3.4.23)
     sass-rails (5.0.6)
@@ -528,15 +278,11 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sawyer (0.6.0)
-      addressable (~> 2.3.5)
-      faraday (~> 0.8, < 0.10)
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     secure_headers (2.5.1)
       user_agent_parser
-    semverse (1.2.1)
     sexp_processor (4.6.1)
     shellany (0.0.1)
     shoulda (3.5.0)
@@ -576,9 +322,6 @@ GEM
       railties (>= 3.1, < 5.0)
       slim (~> 3.0)
     slop (3.6.0)
-    solve (2.0.2)
-      molinillo (~> 0.2.3)
-      semverse (~> 1.1)
     sparkr (0.4.1)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
@@ -588,7 +331,6 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
-    systemu (2.6.5)
     temple (0.7.6)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
@@ -601,8 +343,6 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.6)
     timecop (0.8.0)
-    timers (4.0.4)
-      hitimes
     tins (1.8.2)
     turbolinks (2.5.3)
       coffee-rails
@@ -615,10 +355,6 @@ GEM
       unf_ext
     unf_ext (0.0.7.2)
     user_agent_parser (2.3.0)
-    uuidtools (2.1.5)
-    varia_model (0.4.1)
-      buff-extensions (~> 1.0)
-      hashie (>= 2.0.2, < 4.0.0)
     webmock (3.1.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -626,15 +362,6 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    winrm (1.7.1)
-      builder (>= 2.1.2)
-      gssapi (~> 1.2)
-      gyoku (~> 1.0)
-      httpclient (~> 2.2, >= 2.2.0.2)
-      logging (>= 1.6.1, < 3.0)
-      nori (~> 2.0)
-      rubyntlm (~> 0.6.0)
-    wmi-lite (1.0.0)
     xpath (2.1.0)
       nokogiri (~> 1.3)
     yard (0.8.7.6)
@@ -644,11 +371,9 @@ PLATFORMS
 
 DEPENDENCIES
   autoprefixer-rails
-  berkshelf
   better_errors
   binding_of_caller
   brakeman
-  capistrano-rails
   capybara (~> 2.3.0)
   capybara-screenshot
   coffee-rails (~> 4.0.0)
@@ -661,9 +386,6 @@ DEPENDENCIES
   guard-rspec
   inch
   jbuilder (~> 2.0)
-  knife-ec2
-  knife-solo!
-  knife-solo_data_bag
   launchy
   pg
   poltergeist
@@ -676,7 +398,6 @@ DEPENDENCIES
   rspec-collection_matchers
   rspec-html-matchers
   rspec-rails (~> 3.1.0)
-  rvm-capistrano
   sass-rails
   sdoc (~> 0.4.0)
   secure_headers
@@ -699,4 +420,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.0


### PR DESCRIPTION
__Why__

* This hasn't been used for awhile, there are no active docs to support these libs and the plan is to move to something like Terraform any how.

__How__

* Remove devops group from Gemfile and rebundle.