### PR TITLE
[Issue #146] Fixes expired message bug

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -47,7 +47,7 @@ class MessagesController < ApplicationController
   private
 
   def set_message
-    @message = Message.find_by_token(params[:token])
+    @message = Message.find_active_by_token(params[:token])
   end
 
   def message_params

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -13,6 +13,11 @@ class Message < ActiveRecord::Base
     HUMANIZED_ATTRIBUTES[attr.to_sym] || super
   end
 
+  def self.find_active_by_token(token)
+    message = Message.find_by(token: token)
+    message unless message && message.expired?
+  end
+
   def add_view
     self.update_attribute :views, (self.views.to_i + 1)
     self.destroy if self.expired?

--- a/spec/workers/message_expiry_worker_spec.rb
+++ b/spec/workers/message_expiry_worker_spec.rb
@@ -7,26 +7,25 @@ Rails.application.load_tasks
 
 describe 'Message Expiration Worker' do
   before do
-    # Redis.connect(ENV['REDIS_URL']) 
-    # redis.flushdb
-
-    Message.create(body: 'I am a message')
+    Message.destroy_all
     Message.create(body: 'I am a message', hours: 1)
     Message.create(body: 'I am a message', hours: 2)
     Message.create(body: 'I am a message', hours: 3)
+    Message.create(body: 'I am a message', hours: 4)
   end
 
   it 'erases expired messages' do
     Timecop.freeze(Time.now + 1.hour + 10.minutes)
     MessageExpiryWorker.new.perform
-    expect(Message.all.length).to eq(3)
+    expect(Message.count).to eq(3)
   end
 
   it 'does not erase messages that are not expired' do
-    Timecop.freeze(Time.now + 1.hour + 10.minutes)
+    Timecop.freeze(Time.now + 2.hours + 10.minutes)
     MessageExpiryWorker.new.perform
     Message.all.each do |m|
       expect(m.expired?).to eq(false)
     end
+    expect(Message.count).to eq(2)
   end
 end


### PR DESCRIPTION
### Resolves https://github.com/fugacious/fugacious/issues/146

#### Why
Currently, an expired message will still be displayed to a user if it exists in the database. This could be caused by the MessageExpiryWorker failing or during the window between a message expiration and the worker trigger event. Either way, an expired message should not be able to be viewed beyond the allotted time. 

#### How
Checks expiry status when retrieving messages from the database for the case where an expired message was never viewed or not deleted from the database by the MessageExpiryWorker. 