### PR TITLE
Removes inch from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ group :development, :test do
   gem 'brakeman', require: false
   gem 'coveralls', require: false
   gem 'factory_girl_rails'
-  gem 'inch', require: false
   gem 'pry-nav'
   gem 'rspec-rails', '~> 3.1.0'
   gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,11 +150,6 @@ GEM
       concurrent-ruby (~> 1.0)
     i18n-globals (0.0.4)
       i18n
-    inch (0.7.0)
-      pry
-      sparkr (>= 0.2.0)
-      term-ansicolor
-      yard (~> 0.8.7.5)
     jbuilder (2.4.0)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -326,7 +321,6 @@ GEM
       railties (>= 3.1, < 5.0)
       slim (~> 3.0)
     slop (3.6.0)
-    sparkr (0.4.1)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -368,7 +362,6 @@ GEM
     websocket-extensions (0.1.2)
     xpath (2.1.0)
       nokogiri (~> 1.3)
-    yard (0.8.7.6)
 
 PLATFORMS
   ruby
@@ -390,7 +383,6 @@ DEPENDENCIES
   guard-rails
   guard-rspec
   i18n-globals
-  inch
   jbuilder (~> 2.0)
   launchy
   pg


### PR DESCRIPTION
**Why**
Known vulnerability exists in yard 0.8.7.6
https://nvd.nist.gov/vuln/detail/CVE-2017-17042

**How**
Removes `inch` gem since we're not utilizing it anyway.