### PR TITLE
Updates rack-protection gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,8 +196,8 @@ GEM
     puma (3.10.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.8)
-    rack-protection (1.5.3)
+    rack (1.6.10)
+    rack-protection (2.0.2)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)


### PR DESCRIPTION
Addresses [CVE-2018-1000119](https://nvd.nist.gov/vuln/detail/CVE-2018-1000119) in rack-protection gem