### PR TITLE
Update sprockets gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,7 +323,7 @@ GEM
       slim (~> 3.0)
     slop (3.6.0)
     sparkr (0.4.1)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
We're not using sprockets server but it can't hurt to update the gem. RE: https://nvd.nist.gov/vuln/detail/CVE-2018-3760