### PR TITLE
Bump the base image version to match what the Gemfile expects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1
+FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get install -y 
 RUN apt-get update && apt-get install -y \
         build-essential \


### PR DESCRIPTION
The current `Dockerfile` uses a version of ruby different than what's in the `Gemfile` which causes docker builds to fail with:

```
Warning: the running version of Bundler (1.13.6) is older than the version that created the lockfile (1.16.0). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Your Ruby version is 2.3.1, but your Gemfile specified ~> 2.4.2
Warning: the running version of Bundler (1.13.6) is older than the version that created the lockfile (1.16.0). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Your Ruby version is 2.3.1, but your Gemfile specified ~> 2.4.2
command failed (pid 17 exit 18): bundle check || bundle install
The command '/bin/sh -c bin/setup' returned a non-zero code: 1
```

This one-liner bumps the version to match